### PR TITLE
feat: improve meme generator UX with input validation and user feedback

### DIFF
--- a/lib/constants/MemeOptions.ts
+++ b/lib/constants/MemeOptions.ts
@@ -1,0 +1,23 @@
+export interface MemeOption {
+    value: string;
+    label: string;
+    type: "image" | "text";
+}
+
+export const MemeOptions: MemeOption[] = [
+  { value: "trash", label: "Trash", type: "image" },
+  { value: "vr", label: "VR", type: "text" },
+  { value: "dab", label: "Dab", type: "image" },
+  { value: "disability", label: "Disability", type: "image" },
+  { value: "door", label: "Door", type: "image" },
+  { value: "egg", label: "Egg", type: "image"},
+  { value: "excuseme", label: "Excuse Me", type: "text" },
+  { value: "failure", label: "Failure", type: "image" },
+  { value: "hitler", label: "Hitler", type: "image" },
+  { value: "humanity", label: "Humanity", type: "text" },
+  { value: "idelete", label: "Delete", type: "image" },
+  { value: "jail", label: "Jail", type: "image" },
+  { value: "roblox", label: "Roblox", type: "image" },
+  { value: "satan", label: "Satan", type: "image" },
+  { value: "stonks", label: "Stonks", type: "text" }
+];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,57 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Validates if a string is a valid URL that could potentially be an image URL
+ * @param text The text to validate as URL
+ * @param checkImageHints Whether to check for image-related hints in the URL (optional, default: false)
+ * @returns boolean indicating if the text is a valid URL
+ */
+export function isValidImageUrl(text: string, checkImageHints: boolean = false): boolean {
+  // Basic check if the input is empty or not a string
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+
+  // Use URL constructor for basic URL validation
+  try {
+    const url = new URL(text);
+    
+    // Check if protocol is http or https
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false;
+    }
+    
+    // Optional: Check for image-related hints in the URL
+    if (checkImageHints) {
+      // Common image file extensions
+      const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg', '.tiff', '.ico', '.avif'];
+      
+      // Check for image extensions in the pathname
+      const hasImageExtension = imageExtensions.some(ext => 
+        url.pathname.toLowerCase().endsWith(ext)
+      );
+      
+      // Check for image-related patterns in the URL path or query parameters
+      const lowercaseUrl = url.toString().toLowerCase();
+      const hasImagePattern = 
+        /\/img\/|\/image\/|\/images\/|\/media\/|\/photos\/|\/thumbnails\/|\/picture\//.test(lowercaseUrl) ||
+        /[?&](image|img|photo|pic)=/.test(lowercaseUrl) ||
+        /\/(media|content|cdn|assets)\//.test(lowercaseUrl);
+        
+      // If neither condition is met, it might not be an image URL
+      if (!hasImageExtension && !hasImagePattern) {
+        // Still allow CDN URLs that often don't have extensions or clear patterns
+        const isCdnUrl = /cloudinary\.com|cloudfront\.net|imgur\.com|imgix\.net|res\.cloudinary\.com/.test(lowercaseUrl);
+        if (!isCdnUrl) {
+          return false;
+        }
+      }
+    }
+    
+    return true;
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
This commit enhances the user experience of the meme generator by:

- Adding input validation to help users select the correct content type for each meme
- Creating a `isValidImageUrl` utility function to validate image URLs
- Refactoring meme options into a typed constant array with explicit "image" or "text" types
- Implementing a feedback system that displays helpful alert messages when input doesn't match the required type
- Adding auto-dismissal of error messages after 5 seconds for better UX
- Updating button text to "Fix Error" when serious errors are detected
- Disabling the generate button for serious errors while allowing submission for passable warnings

These changes solve the confusion around which meme types require image URLs versus text input, providing clear guidance to users and preventing failed meme generation attempts.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, new provider, refactoring, etc… -->

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Other information**